### PR TITLE
Ci changes

### DIFF
--- a/group_vars/devstack
+++ b/group_vars/devstack
@@ -54,4 +54,4 @@ git_prep_projects:
   - openstack/swift
   - openstack/tempest
 
-image_urls: http://10.100.0.9/ci/cirros-0.3.3-x86_64.vhdx
+image_urls: http://10.100.0.9/ci/ubuntu-16.04-minimal-cloudimg-amd64.vhdx

--- a/group_vars/devstack-cinder-iscsi
+++ b/group_vars/devstack-cinder-iscsi
@@ -139,6 +139,8 @@ post_stack_bash: |
     TEMPEST_CONFIG={{ devstack_dir.stack }}/tempest/etc/tempest.conf
     iniset $TEMPEST_CONFIG compute volume_device_name "sdb"
     iniset $TEMPEST_CONFIG compute min_compute_nodes {{ win2016_compute_nodes | length }}
+    iniset $TEMPEST_CONFIG compute flavor_ref 452
+    iniset $TEMPEST_CONFIG compute flavor_ref_alt 451
     iniset $TEMPEST_CONFIG compute-feature-enabled rdp_console true
     iniset $TEMPEST_CONFIG compute-feature-enabled block_migrate_cinder_iscsi False
     iniset $TEMPEST_CONFIG compute-feature-enabled block_migration_for_live_migration False
@@ -149,9 +151,11 @@ post_stack_bash: |
     iniset $TEMPEST_CONFIG scenario img_dir "/home/ubuntu/devstack/files/"
     iniset $TEMPEST_CONFIG scenario img_file "{{ local_conf.image_urls | basename }}"
     iniset $TEMPEST_CONFIG scenario img_disk_format vhdx
+    iniset $TEMPEST_CONFIG scenario dhcp_client dhclient
 
     IMAGE_REF=`iniget $TEMPEST_CONFIG compute image_ref`
     iniset $TEMPEST_CONFIG compute image_ref_alt $IMAGE_REF
+    iniset $TEMPEST_CONFIG validation image_ssh_user ubuntu
 
     iniset $TEMPEST_CONFIG compute build_timeout 360
     iniset $TEMPEST_CONFIG orchestration build_timeout 360

--- a/group_vars/devstack-cinder-smb
+++ b/group_vars/devstack-cinder-smb
@@ -138,6 +138,8 @@ post_stack_bash: |
     TEMPEST_CONFIG={{ devstack_dir.stack }}/tempest/etc/tempest.conf
     iniset $TEMPEST_CONFIG compute volume_device_name "sdb"
     iniset $TEMPEST_CONFIG compute min_compute_nodes {{ win2016_compute_nodes | length }}
+    iniset $TEMPEST_CONFIG compute flavor_ref 452
+    iniset $TEMPEST_CONFIG compute flavor_ref_alt 451
     iniset $TEMPEST_CONFIG compute-feature-enabled rdp_console true
     iniset $TEMPEST_CONFIG compute-feature-enabled block_migrate_cinder_iscsi False
     iniset $TEMPEST_CONFIG compute-feature-enabled block_migration_for_live_migration False
@@ -148,9 +150,11 @@ post_stack_bash: |
     iniset $TEMPEST_CONFIG scenario img_dir "/home/ubuntu/devstack/files/"
     iniset $TEMPEST_CONFIG scenario img_file "{{ local_conf.image_urls | basename }}"
     iniset $TEMPEST_CONFIG scenario img_disk_format vhdx
+    iniset $TEMPEST_CONFIG scenario dhcp_client dhclient
 
     IMAGE_REF=`iniget $TEMPEST_CONFIG compute image_ref`
     iniset $TEMPEST_CONFIG compute image_ref_alt $IMAGE_REF
+    iniset $TEMPEST_CONFIG validation image_ssh_user ubuntu
 
     iniset $TEMPEST_CONFIG compute build_timeout 360
     iniset $TEMPEST_CONFIG orchestration build_timeout 360

--- a/group_vars/devstack-neutron-ovs
+++ b/group_vars/devstack-neutron-ovs
@@ -221,6 +221,8 @@ post_stack_bash: |
     TEMPEST_CONFIG={{ devstack_dir.stack }}/tempest/etc/tempest.conf
     iniset $TEMPEST_CONFIG compute volume_device_name "sdb"
     iniset $TEMPEST_CONFIG compute min_compute_nodes {{ win2016_compute_nodes | length }}
+    iniset $TEMPEST_CONFIG compute flavor_ref 452
+    iniset $TEMPEST_CONFIG compute flavor_ref_alt 451
     iniset $TEMPEST_CONFIG compute-feature-enabled rdp_console true
     iniset $TEMPEST_CONFIG compute-feature-enabled block_migrate_cinder_iscsi True
     iniset $TEMPEST_CONFIG compute-feature-enabled block_migration_for_live_migration True
@@ -230,9 +232,11 @@ post_stack_bash: |
     iniset $TEMPEST_CONFIG scenario img_dir "/home/ubuntu/devstack/files/"
     iniset $TEMPEST_CONFIG scenario img_file "{{ local_conf.image_urls | basename }}"
     iniset $TEMPEST_CONFIG scenario img_disk_format vhdx
+    iniset $TEMPEST_CONFIG scenario dhcp_client dhclient
 
     IMAGE_REF=`iniget $TEMPEST_CONFIG compute image_ref`
     iniset $TEMPEST_CONFIG compute image_ref_alt $IMAGE_REF
+    iniset $TEMPEST_CONFIG validation image_ssh_user ubuntu
 
     iniset $TEMPEST_CONFIG compute build_timeout 360
     iniset $TEMPEST_CONFIG orchestration build_timeout 360

--- a/group_vars/devstack-nova
+++ b/group_vars/devstack-nova
@@ -215,6 +215,8 @@ post_stack_bash: |
     TEMPEST_CONFIG={{ devstack_dir.stack }}/tempest/etc/tempest.conf
     iniset $TEMPEST_CONFIG compute volume_device_name "sdb"
     iniset $TEMPEST_CONFIG compute min_compute_nodes {{ win2016_compute_nodes | length }}
+    iniset $TEMPEST_CONFIG compute flavor_ref 452
+    iniset $TEMPEST_CONFIG compute flavor_ref_alt 451
     iniset $TEMPEST_CONFIG compute-feature-enabled rdp_console true
     iniset $TEMPEST_CONFIG compute-feature-enabled block_migrate_cinder_iscsi True
     iniset $TEMPEST_CONFIG compute-feature-enabled block_migration_for_live_migration True
@@ -224,9 +226,11 @@ post_stack_bash: |
     iniset $TEMPEST_CONFIG scenario img_dir "/home/ubuntu/devstack/files/"
     iniset $TEMPEST_CONFIG scenario img_file "{{ local_conf.image_urls | basename }}"
     iniset $TEMPEST_CONFIG scenario img_disk_format vhdx
+    iniset $TEMPEST_CONFIG scenario dhcp_client dhclient
 
     IMAGE_REF=`iniget $TEMPEST_CONFIG compute image_ref`
     iniset $TEMPEST_CONFIG compute image_ref_alt $IMAGE_REF
+    iniset $TEMPEST_CONFIG validation image_ssh_user ubuntu
 
     iniset $TEMPEST_CONFIG compute build_timeout 360
     iniset $TEMPEST_CONFIG orchestration build_timeout 360

--- a/group_vars/devstack-os-brick-fc
+++ b/group_vars/devstack-os-brick-fc
@@ -161,6 +161,8 @@ post_stack_bash: |
     TEMPEST_CONFIG={{ devstack_dir.stack }}/tempest/etc/tempest.conf
     iniset $TEMPEST_CONFIG compute volume_device_name "sdb"
     iniset $TEMPEST_CONFIG compute min_compute_nodes {{ win2016_compute_nodes | length }}
+    iniset $TEMPEST_CONFIG compute flavor_ref 452
+    iniset $TEMPEST_CONFIG compute flavor_ref_alt 451
     iniset $TEMPEST_CONFIG compute-feature-enabled rdp_console true
     iniset $TEMPEST_CONFIG compute-feature-enabled block_migrate_cinder_iscsi False
     iniset $TEMPEST_CONFIG compute-feature-enabled block_migration_for_live_migration False
@@ -171,9 +173,11 @@ post_stack_bash: |
     iniset $TEMPEST_CONFIG scenario img_dir "/home/ubuntu/devstack/files/"
     iniset $TEMPEST_CONFIG scenario img_file "{{ local_conf.image_urls | basename }}"
     iniset $TEMPEST_CONFIG scenario img_disk_format vhdx
+    iniset $TEMPEST_CONFIG scenario dhcp_client dhclient
 
     IMAGE_REF=`iniget $TEMPEST_CONFIG compute image_ref`
     iniset $TEMPEST_CONFIG compute image_ref_alt $IMAGE_REF
+    iniset $TEMPEST_CONFIG validation image_ssh_user ubuntu
 
     iniset $TEMPEST_CONFIG compute build_timeout 360
     iniset $TEMPEST_CONFIG orchestration build_timeout 360

--- a/group_vars/devstack-os-brick-iscsi
+++ b/group_vars/devstack-os-brick-iscsi
@@ -138,6 +138,8 @@ post_stack_bash: |
     TEMPEST_CONFIG={{ devstack_dir.stack }}/tempest/etc/tempest.conf
     iniset $TEMPEST_CONFIG compute volume_device_name "sdb"
     iniset $TEMPEST_CONFIG compute min_compute_nodes {{ win2016_compute_nodes | length }}
+    iniset $TEMPEST_CONFIG compute flavor_ref 452
+    iniset $TEMPEST_CONFIG compute flavor_ref_alt 451
     iniset $TEMPEST_CONFIG compute-feature-enabled rdp_console true
     iniset $TEMPEST_CONFIG compute-feature-enabled block_migrate_cinder_iscsi False
     iniset $TEMPEST_CONFIG compute-feature-enabled block_migration_for_live_migration False
@@ -148,9 +150,11 @@ post_stack_bash: |
     iniset $TEMPEST_CONFIG scenario img_dir "/home/ubuntu/devstack/files/"
     iniset $TEMPEST_CONFIG scenario img_file "{{ local_conf.image_urls | basename }}"
     iniset $TEMPEST_CONFIG scenario img_disk_format vhdx
+    iniset $TEMPEST_CONFIG scenario dhcp_client dhclient
 
     IMAGE_REF=`iniget $TEMPEST_CONFIG compute image_ref`
     iniset $TEMPEST_CONFIG compute image_ref_alt $IMAGE_REF
+    iniset $TEMPEST_CONFIG validation image_ssh_user ubuntu
 
     iniset $TEMPEST_CONFIG compute build_timeout 360
     iniset $TEMPEST_CONFIG orchestration build_timeout 360

--- a/group_vars/devstack-os-brick-smb
+++ b/group_vars/devstack-os-brick-smb
@@ -138,6 +138,8 @@ post_stack_bash: |
     TEMPEST_CONFIG={{ devstack_dir.stack }}/tempest/etc/tempest.conf
     iniset $TEMPEST_CONFIG compute volume_device_name "sdb"
     iniset $TEMPEST_CONFIG compute min_compute_nodes {{ win2016_compute_nodes | length }}
+    iniset $TEMPEST_CONFIG compute flavor_ref 452
+    iniset $TEMPEST_CONFIG compute flavor_ref_alt 451
     iniset $TEMPEST_CONFIG compute-feature-enabled rdp_console true
     iniset $TEMPEST_CONFIG compute-feature-enabled block_migrate_cinder_iscsi False
     iniset $TEMPEST_CONFIG compute-feature-enabled block_migration_for_live_migration False
@@ -148,9 +150,11 @@ post_stack_bash: |
     iniset $TEMPEST_CONFIG scenario img_dir "/home/ubuntu/devstack/files/"
     iniset $TEMPEST_CONFIG scenario img_file "{{ local_conf.image_urls | basename }}"
     iniset $TEMPEST_CONFIG scenario img_disk_format vhdx
+    iniset $TEMPEST_CONFIG scenario dhcp_client dhclient
 
     IMAGE_REF=`iniget $TEMPEST_CONFIG compute image_ref`
     iniset $TEMPEST_CONFIG compute image_ref_alt $IMAGE_REF
+    iniset $TEMPEST_CONFIG validation image_ssh_user ubuntu
 
     iniset $TEMPEST_CONFIG compute build_timeout 360
     iniset $TEMPEST_CONFIG orchestration build_timeout 360

--- a/job_vars/cinder-iscsi
+++ b/job_vars/cinder-iscsi
@@ -2,14 +2,14 @@ vms:
   - devstack: 
     name: "dv-cinder-{{ zuul_change }}-{{ zuul_patchset }}-{{ job_type }}"
     image: ubuntu1604
-    flavor: devstack
-    inventory_group: devstack
+    flavor: ci-devstack
+    inventory_group: ci-devstack
     additional_params: 'ansible_ssh_private_key_file=/home/jenkins-slave/.ssh/id_rsa.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'
     userdata: ""
   - hv2016-compute: 
     name: "hv-cinder-{{ zuul_change }}-{{ zuul_patchset }}-{{ job_type }}"
     image: win2016-hypervrole
-    flavor: win2016hv
+    flavor: ci-win2016hv
     inventory_group: win2016-compute
     additional_params: "ansible_winrm_cert_pem=/home/jenkins-slave/ssl/ssl_winrm.crt ansible_winrm_cert_key_pem=/home/jenkins-slave/ssl/ssl_winrm.key ansible_winrm_transport=certificate ansible_ssh_user=administrator ansible_connection=winrm ansible_winrm_server_cert_validation=ignore ansible_ssh_port=5986"
     userdata: "{{ lookup('file', '/home/jenkins-slave/ssl/ssl_winrm.crt') }}"

--- a/job_vars/cinder-iscsi
+++ b/job_vars/cinder-iscsi
@@ -3,7 +3,7 @@ vms:
     name: "dv-cinder-{{ zuul_change }}-{{ zuul_patchset }}-{{ job_type }}"
     image: ubuntu1604
     flavor: ci-devstack
-    inventory_group: ci-devstack
+    inventory_group: devstack
     additional_params: 'ansible_ssh_private_key_file=/home/jenkins-slave/.ssh/id_rsa.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'
     userdata: ""
   - hv2016-compute: 

--- a/job_vars/cinder-smb
+++ b/job_vars/cinder-smb
@@ -2,14 +2,14 @@ vms:
   - devstack: 
     name: "dv-cinder-{{ zuul_change }}-{{ zuul_patchset }}-{{ job_type }}"
     image: ubuntu1604
-    flavor: devstack
+    flavor: ci-devstack
     inventory_group: devstack
     additional_params: 'ansible_ssh_private_key_file=/home/jenkins-slave/.ssh/id_rsa.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'
     userdata: ""
   - hv2016-compute: 
     name: "hv-cinder-{{ zuul_change }}-{{ zuul_patchset }}-{{ job_type }}"
     image: win2016-hypervrole
-    flavor: win2016hv
+    flavor: ci-win2016hv
     inventory_group: win2016-compute
     additional_params: "ansible_winrm_cert_pem=/home/jenkins-slave/ssl/ssl_winrm.crt ansible_winrm_cert_key_pem=/home/jenkins-slave/ssl/ssl_winrm.key ansible_winrm_transport=certificate ansible_ssh_user=administrator ansible_connection=winrm ansible_winrm_server_cert_validation=ignore ansible_ssh_port=5986"
     userdata: "{{ lookup('file', '/home/jenkins-slave/ssl/ssl_winrm.crt') }}"

--- a/job_vars/neutron-ovs
+++ b/job_vars/neutron-ovs
@@ -2,14 +2,14 @@ vms:
   - devstack: 
     name: "dv-neutron-{{ zuul_change }}-{{ zuul_patchset }}-{{ network_type }}"
     image: ubuntu1604
-    flavor: devstack
+    flavor: ci-devstack
     inventory_group: devstack
     additional_params: 'ansible_ssh_private_key_file=/home/jenkins-slave/.ssh/id_rsa.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'
     userdata: ""
   - hv2016-compute: 
     name: "hv-neutron-{{ zuul_change }}-{{ zuul_patchset }}-{{ network_type }}"
     image: win2016-hypervrole
-    flavor: win2016hv
+    flavor: ci-win2016hv
     inventory_group: win2016-compute
     additional_params: "ansible_winrm_cert_pem=/home/jenkins-slave/ssl/ssl_winrm.crt ansible_winrm_cert_key_pem=/home/jenkins-slave/ssl/ssl_winrm.key ansible_winrm_transport=certificate ansible_ssh_user=administrator ansible_connection=winrm ansible_winrm_server_cert_validation=ignore ansible_ssh_port=5986"
     userdata: "{{ lookup('file', '/home/jenkins-slave/ssl/ssl_winrm.crt') }}"

--- a/job_vars/nova
+++ b/job_vars/nova
@@ -2,28 +2,28 @@ vms:
   - devstack: 
     name: "n-d-{{ zuul_change }}-{{ zuul_patchset }}"
     image: ubuntu1604
-    flavor: devstack
+    flavor: ci-devstack
     inventory_group: devstack
     additional_params: 'ansible_ssh_private_key_file=/home/jenkins-slave/.ssh/id_rsa.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'
     userdata: ""
   - hv2016-compute: 
     name: "n-h1-{{ zuul_change }}-{{ zuul_patchset }}"
     image: win2016-hypervrole
-    flavor: win2016hv
+    flavor: ci-win2016hv
     inventory_group: win2016-compute
     additional_params: "ansible_winrm_cert_pem=/home/jenkins-slave/ssl/ssl_winrm.crt ansible_winrm_cert_key_pem=/home/jenkins-slave/ssl/ssl_winrm.key ansible_winrm_transport=certificate ansible_ssh_user=administrator ansible_connection=winrm ansible_winrm_server_cert_validation=ignore ansible_ssh_port=5986"
     userdata: "{{ lookup('file', '/home/jenkins-slave/ssl/ssl_winrm.crt') }}"
   - hv2016-compute:
     name: "n-h2-{{ zuul_change }}-{{ zuul_patchset }}"
     image: win2016-hypervrole
-    flavor: win2016hv
+    flavor: ci-win2016hv
     inventory_group: win2016-compute
     additional_params: "ansible_winrm_cert_pem=/home/jenkins-slave/ssl/ssl_winrm.crt ansible_winrm_cert_key_pem=/home/jenkins-slave/ssl/ssl_winrm.key ansible_winrm_transport=certificate ansible_ssh_user=administrator ansible_connection=winrm ansible_winrm_server_cert_validation=ignore ansible_ssh_port=5986"
     userdata: "{{ lookup('file', '/home/jenkins-slave/ssl/ssl_winrm.crt') }}"
   - hv2016-ad:
     name: "n-ad-{{ zuul_change }}-{{ zuul_patchset }}"
     image: win2016-hypervrole
-    flavor: win2016hv
+    flavor: ci-win2016hv
     inventory_group: ad
     additional_params: "ansible_winrm_cert_pem=/home/jenkins-slave/ssl/ssl_winrm.crt ansible_winrm_cert_key_pem=/home/jenkins-slave/ssl/ssl_winrm.key ansible_winrm_transport=certificate ansible_ssh_user=administrator ansible_connection=winrm ansible_winrm_server_cert_validation=ignore ansible_ssh_port=5986"
     userdata: "{{ lookup('file', '/home/jenkins-slave/ssl/ssl_winrm.crt') }}"

--- a/job_vars/os-brick-fc
+++ b/job_vars/os-brick-fc
@@ -2,7 +2,7 @@ vms:
   - devstack: 
     name: "dv-osbrick-{{ zuul_change }}-{{ zuul_patchset }}-{{ job_type }}"
     image: ubuntu1604
-    flavor: devstack
+    flavor: ci-devstack
     availability_zone: "os-brick-fc"
     inventory_group: devstack
     additional_params: 'ansible_ssh_private_key_file=/home/jenkins-slave/.ssh/id_rsa.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'
@@ -10,7 +10,7 @@ vms:
   - hv2016-compute: 
     name: "hv-osbrick-{{ zuul_change }}-{{ zuul_patchset }}-{{ job_type }}"
     image: win2016-hypervrole
-    flavor: win2016hv
+    flavor: ci-win2016hv
     availability_zone: "os-brick-fc"
     inventory_group: win2016-compute
     additional_params: "ansible_winrm_cert_pem=/home/jenkins-slave/ssl/ssl_winrm.crt ansible_winrm_cert_key_pem=/home/jenkins-slave/ssl/ssl_winrm.key ansible_winrm_transport=certificate ansible_ssh_user=administrator ansible_connection=winrm ansible_winrm_server_cert_validation=ignore ansible_ssh_port=5986"

--- a/job_vars/os-brick-iscsi
+++ b/job_vars/os-brick-iscsi
@@ -2,14 +2,14 @@ vms:
   - devstack: 
     name: "dv-osbrick-{{ zuul_change }}-{{ zuul_patchset }}-{{ job_type }}"
     image: ubuntu1604
-    flavor: devstack
+    flavor: ci-devstack
     inventory_group: devstack
     additional_params: 'ansible_ssh_private_key_file=/home/jenkins-slave/.ssh/id_rsa.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'
     userdata: ""
   - hv2016-compute: 
     name: "hv-osbrick-{{ zuul_change }}-{{ zuul_patchset }}-{{ job_type }}"
     image: win2016-hypervrole
-    flavor: win2016hv
+    flavor: ci-win2016hv
     inventory_group: win2016-compute
     additional_params: "ansible_winrm_cert_pem=/home/jenkins-slave/ssl/ssl_winrm.crt ansible_winrm_cert_key_pem=/home/jenkins-slave/ssl/ssl_winrm.key ansible_winrm_transport=certificate ansible_ssh_user=administrator ansible_connection=winrm ansible_winrm_server_cert_validation=ignore ansible_ssh_port=5986"
     userdata: "{{ lookup('file', '/home/jenkins-slave/ssl/ssl_winrm.crt') }}"

--- a/job_vars/os-brick-smb
+++ b/job_vars/os-brick-smb
@@ -2,14 +2,14 @@ vms:
   - devstack: 
     name: "dv-osbrick-{{ zuul_change }}-{{ zuul_patchset }}-{{ job_type }}"
     image: ubuntu1604
-    flavor: devstack
+    flavor: ci-devstack
     inventory_group: devstack
     additional_params: 'ansible_ssh_private_key_file=/home/jenkins-slave/.ssh/id_rsa.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'
     userdata: ""
   - hv2016-compute: 
     name: "hv-osbrick-{{ zuul_change }}-{{ zuul_patchset }}-{{ job_type }}"
     image: win2016-hypervrole
-    flavor: win2016hv
+    flavor: ci-win2016hv
     inventory_group: win2016-compute
     additional_params: "ansible_winrm_cert_pem=/home/jenkins-slave/ssl/ssl_winrm.crt ansible_winrm_cert_key_pem=/home/jenkins-slave/ssl/ssl_winrm.key ansible_winrm_transport=certificate ansible_ssh_user=administrator ansible_connection=winrm ansible_winrm_server_cert_validation=ignore ansible_ssh_port=5986"
     userdata: "{{ lookup('file', '/home/jenkins-slave/ssl/ssl_winrm.crt') }}"

--- a/templates/devstack/local.sh
+++ b/templates/devstack/local.sh
@@ -10,7 +10,8 @@ nova flavor-delete 451 || echo "Flavor 42 not found"
 
 nova flavor-create m1.nano 42 256 1 1
 nova flavor-create m1.micro 84 256 2 1
-nova flavor-create m1.heat 451 512 5 1
+nova flavor-create m1.heat 451 512 2 1
+nova flavor-create m1.heat2 452 1024 2 1
 
 echo "After updating nova flavors:"
 nova flavor-list

--- a/templates/devstack/local.sh
+++ b/templates/devstack/local.sh
@@ -10,8 +10,8 @@ nova flavor-delete 451 || echo "Flavor 42 not found"
 
 nova flavor-create m1.nano 42 256 1 1
 nova flavor-create m1.micro 84 256 2 1
-nova flavor-create m1.heat 451 512 2 1
-nova flavor-create m1.heat2 452 1024 2 1
+nova flavor-create m1.heat 451 512 1 1
+nova flavor-create m1.heat2 452 1024 1 1
 
 echo "After updating nova flavors:"
 nova flavor-list


### PR DESCRIPTION
- Changed image used for tempest from cirros 0.3.3 to ubuntu 16.04 (kernel: 4.15.0-1018-azure kernel);
- default ssh username-password pair (ubuntu:ubuntu);
- configured tempest tu use as dhcp_client while testing, dhclient;
- configured tempest to use as ssh user, ubuntu;
- configured tempest to use as flavors 452 (1GB RAM - 1 GB disk space - 1 vcpu) and 451 (512MB RAM - 1 GB disk space - 1 vcpu)
- changed the flavors used for building VMs used in creation of job environments: http://paste.openstack.org/show/730994/