### PR TITLE
change os-vif from 1.12.0 to 1.11.0

### DIFF
--- a/build-win2016.yaml
+++ b/build-win2016.yaml
@@ -110,6 +110,9 @@
     - name: Change pbr version from 4.0.0 to 3.1.1
       win_shell: '(gc {{ win_dir.build }}\\requirements\\upper-constraints.txt) -replace "^pbr.*", "pbr===3.1.1" | Set-Content {{ win_dir.build }}\\requirements\\upper-constraints.txt'
 
+    - name: Change os-vif version from 1.12.0 to 1.11.0
+      win_shell: '(gc {{ win_dir.build }}\\requirements\\upper-constraints.txt) -replace "^os-vif.*", "os-vif===1.11.0" | Set-Content {{ win_dir.build }}\\requirements\\upper-constraints.txt'
+
     - name: Installing pip packages
       win_shell: "pip install -c {{ win_dir.build }}\\requirements\\upper-constraints.txt -U {{ python_packages | join(' ') }}"
       when: python_packages is defined


### PR DESCRIPTION
Fix to newly merged commit: https://github.com/openstack/requirements/commit/4809b0e726c3d34b593a93968b8c166bb225d5f3

Problem: ovs plugin no longer loads on Windows: https://bugs.launchpad.net/os-vif/+bug/1801029