### PR TITLE
ci tempest test image change

### DIFF
--- a/group_vars/devstack
+++ b/group_vars/devstack
@@ -54,4 +54,4 @@ git_prep_projects:
   - openstack/swift
   - openstack/tempest
 
-image_urls: http://10.100.0.9/ci/ubuntu-16.04-minimal-cloudimg-amd64.vhdx
+image_urls: http://10.100.0.9/ci/ubuntu-16.04-minimal-cloudimg-amd64-sync.vhdx

--- a/job_vars/cinder-iscsi.yaml
+++ b/job_vars/cinder-iscsi.yaml
@@ -223,7 +223,6 @@ tempest_tests:
       tempest.api.volume.test_volumes_extend.VolumesExtendAttachedTest.test_extend_attached_volume
       # feature not supported on iscsi driver
       tempest.api.volume.admin.test_volume_manage.VolumeManageAdminTest.test_unmanage_manage_volume
-      tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern.test_volume_boot_pattern
 
 
 ## windows

--- a/job_vars/cinder-smb.yaml
+++ b/job_vars/cinder-smb.yaml
@@ -222,7 +222,6 @@ tempest_tests:
       # exclude requested by luci, sometimes it fails reading from a diff image while the volume is attached
       tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern
       tempest.api.volume.test_volumes_extend.VolumesExtendAttachedTest.test_extend_attached_volume
-      tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern.test_volume_boot_pattern
 
 
 ## windows

--- a/job_vars/neutron.yaml
+++ b/job_vars/neutron.yaml
@@ -74,7 +74,6 @@ tempest_tests:
       tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_rebuild_server
       tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_rebuild_server_in_stop_state
       tempest.scenario.test_network_v6.TestGettingAddress
-      tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern.test_volume_boot_pattern
 
   isolated-tests: |
       tempest.api.compute.admin.test_servers_negative.ServersAdminNegativeTestJSON.test_resize_server_using_overlimit_ram

--- a/job_vars/nova.yaml
+++ b/job_vars/nova.yaml
@@ -83,7 +83,6 @@ tempest_tests:
       tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_rebuild_server_with_volume_attached
       tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_resize_volume_backed_server_confirm
       tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_shelve_unshelve_server
-      tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern.test_volume_boot_pattern
 
   isolated-tests: |
       tempest.api.compute.admin.test_servers_negative.ServersAdminNegativeTestJSON.test_resize_server_using_overlimit_ram


### PR DESCRIPTION
- Added sync option when mouting cloudimg-rootfs
- Enabled tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern.test_volume_boot_pattern on all CI jobs on master