### PR TITLE
Updated excluded tests fro stable branches

### DIFF
--- a/job_vars/cinder-iscsi.yaml
+++ b/job_vars/cinder-iscsi.yaml
@@ -223,6 +223,7 @@ tempest_tests:
       tempest.api.volume.test_volumes_extend.VolumesExtendAttachedTest.test_extend_attached_volume
       # feature not supported on iscsi driver
       tempest.api.volume.admin.test_volume_manage.VolumeManageAdminTest.test_unmanage_manage_volume
+      tempest.scenario.test_stamp_pattern.TestStampPattern.test_stamp_pattern
 
 
 ## windows

--- a/job_vars/cinder-smb.yaml
+++ b/job_vars/cinder-smb.yaml
@@ -222,6 +222,7 @@ tempest_tests:
       # exclude requested by luci, sometimes it fails reading from a diff image while the volume is attached
       tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern
       tempest.api.volume.test_volumes_extend.VolumesExtendAttachedTest.test_extend_attached_volume
+      tempest.scenario.test_stamp_pattern.TestStampPattern.test_stamp_pattern
 
 
 ## windows

--- a/job_vars/neutron.yaml
+++ b/job_vars/neutron.yaml
@@ -74,6 +74,7 @@ tempest_tests:
       tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_rebuild_server
       tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_rebuild_server_in_stop_state
       tempest.scenario.test_network_v6.TestGettingAddress
+      tempest.scenario.test_stamp_pattern.TestStampPattern.test_stamp_pattern
 
   isolated-tests: |
       tempest.api.compute.admin.test_servers_negative.ServersAdminNegativeTestJSON.test_resize_server_using_overlimit_ram

--- a/job_vars/nova.yaml
+++ b/job_vars/nova.yaml
@@ -83,6 +83,7 @@ tempest_tests:
       tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_rebuild_server_with_volume_attached
       tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_resize_volume_backed_server_confirm
       tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_shelve_unshelve_server
+      tempest.scenario.test_stamp_pattern.TestStampPattern.test_stamp_pattern
 
   isolated-tests: |
       tempest.api.compute.admin.test_servers_negative.ServersAdminNegativeTestJSON.test_resize_server_using_overlimit_ram

--- a/job_vars/os-brick-fc.yaml
+++ b/job_vars/os-brick-fc.yaml
@@ -220,7 +220,8 @@ tempest_tests:
       tempest.scenario.test_stamp_pattern
       tempest.scenario.test_volume_boot_pattern
 
-#  excluded-tests: |
+  excluded-tests: |
+      tempest.scenario.test_stamp_pattern.TestStampPattern.test_stamp_pattern
 
 
 

--- a/job_vars/os-brick-iscsi.yaml
+++ b/job_vars/os-brick-iscsi.yaml
@@ -195,7 +195,8 @@ tempest_tests:
       tempest.scenario.test_stamp_pattern
       tempest.scenario.test_volume_boot_pattern
 
-#  excluded-tests: |
+  excluded-tests: |
+      tempest.scenario.test_stamp_pattern.TestStampPattern.test_stamp_pattern
 
 
 

--- a/job_vars/os-brick-smb.yaml
+++ b/job_vars/os-brick-smb.yaml
@@ -195,7 +195,8 @@ tempest_tests:
       tempest.scenario.test_stamp_pattern
       tempest.scenario.test_volume_boot_pattern
 
-#  excluded-tests: |
+  excluded-tests: |
+      tempest.scenario.test_stamp_pattern.TestStampPattern.test_stamp_pattern
 #      tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern.test_volume_boot_pattern
 
 


### PR DESCRIPTION
tempest.scenario.test_stamp_pattern.TestStampPattern.test_stamp_pattern
is failing on stable branches.