### PR TITLE
Excluded test failing on stable branches

### DIFF
--- a/group_vars/devstack-cinder-iscsi
+++ b/group_vars/devstack-cinder-iscsi
@@ -199,4 +199,5 @@ tempest_tests:
       tempest.api.volume.test_volumes_extend.VolumesExtendAttachedTest.test_extend_attached_volume
       # feature not supported on iscsi driver
       tempest.api.volume.admin.test_volume_manage.VolumeManageAdminTest.test_unmanage_manage_volume
+      tempest.scenario.test_stamp_pattern.TestStampPattern.test_stamp_pattern
 

--- a/group_vars/devstack-cinder-smb
+++ b/group_vars/devstack-cinder-smb
@@ -198,3 +198,4 @@ tempest_tests:
       # exclude requested by luci, sometimes it fails reading from a diff image while the volume is attached
       tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern
       tempest.api.volume.test_volumes_extend.VolumesExtendAttachedTest.test_extend_attached_volume
+      tempest.scenario.test_stamp_pattern.TestStampPattern.test_stamp_pattern

--- a/group_vars/devstack-neutron-ovs
+++ b/group_vars/devstack-neutron-ovs
@@ -50,6 +50,7 @@ tempest_tests:
       tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_rebuild_server
       tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_rebuild_server_in_stop_state
       tempest.scenario.test_network_v6.TestGettingAddress
+      tempest.scenario.test_stamp_pattern.TestStampPattern.test_stamp_pattern
 
   isolated-tests: |
       tempest.api.compute.admin.test_servers_negative.ServersAdminNegativeTestJSON.test_resize_server_using_overlimit_ram

--- a/group_vars/devstack-nova
+++ b/group_vars/devstack-nova
@@ -43,6 +43,7 @@ tempest_tests:
       tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_rebuild_server_with_volume_attached
       tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_resize_volume_backed_server_confirm
       tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_shelve_unshelve_server
+      tempest.scenario.test_stamp_pattern.TestStampPattern.test_stamp_pattern
 
   isolated-tests: |
       tempest.api.compute.admin.test_servers_negative.ServersAdminNegativeTestJSON.test_resize_server_using_overlimit_ram

--- a/group_vars/devstack-os-brick-fc
+++ b/group_vars/devstack-os-brick-fc
@@ -194,5 +194,6 @@ tempest_tests:
       tempest.scenario.test_stamp_pattern
       tempest.scenario.test_volume_boot_pattern
 
-#  excluded-tests: |
+  excluded-tests: |
+      tempest.scenario.test_stamp_pattern.TestStampPattern.test_stamp_pattern
 

--- a/group_vars/devstack-os-brick-iscsi
+++ b/group_vars/devstack-os-brick-iscsi
@@ -171,5 +171,6 @@ tempest_tests:
       tempest.scenario.test_stamp_pattern
       tempest.scenario.test_volume_boot_pattern
 
-#  excluded-tests: |
+  excluded-tests: |
+      tempest.scenario.test_stamp_pattern.TestStampPattern.test_stamp_pattern
 

--- a/group_vars/devstack-os-brick-smb
+++ b/group_vars/devstack-os-brick-smb
@@ -171,6 +171,7 @@ tempest_tests:
       tempest.scenario.test_stamp_pattern
       tempest.scenario.test_volume_boot_pattern
 
-#  excluded-tests: |
+  excluded-tests: |
+      tempest.scenario.test_stamp_pattern.TestStampPattern.test_stamp_pattern
 #      tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern.test_volume_boot_pattern
 


### PR DESCRIPTION
tempest.scenario.test_stamp_pattern.TestStampPattern.test_stamp_pattern
is failing on stable branches