### PR TITLE
Use premade zuul venv

### DIFF
--- a/group_vars/devstack
+++ b/group_vars/devstack
@@ -63,3 +63,4 @@ git_prep_projects:
   - openstack/tempest
 
 image_urls: http://10.100.0.9/ci/ubuntu-16.04-minimal-cloudimg-amd64-sync.vhdx
+zuul_venv_pkg: http://10.100.0.9/ci/zuul-venv-devstack.tar.gz

--- a/tasks/devstack/install-zuul.yaml
+++ b/tasks/devstack/install-zuul.yaml
@@ -1,45 +1,7 @@
-  - name: Create zuul virtual env
-    shell: |
-      /usr/local/bin/virtualenv --no-site-packages --no-setuptools -ppython2.7 "{{ devstack_dir.zuul }}"
-      source /opt/stack/zuul-venv/bin/activate
-      pip install setuptools==44.0.0
-    args:
-      executable: /bin/bash
-    become: True
-    tags: install-zuul
-  
-   # Downgrade gitdb2 library to last working version
-  - name: Downgrade gitdb2 library to version 2.0.5
-    pip:
-      virtualenv: "{{ devstack_dir.zuul }}"
-      name: "gitdb2==2.0.5"
-      virtualenv_python: python2.7
-    become: True
-    tags: install-zuul
-    
-  # Install zuul in a virtualenv, it messes with pbr and other openstack libraries
-  - name: Install zuul version {{ zuul_version }}
-    pip:
-      virtualenv: "{{ devstack_dir.zuul }}"
-      name: "{{ zuul_version }}"
-      virtualenv_python: python2.7
-    become: True
-    tags: install-zuul
-
-  # Workaround for https://github.com/gitpython-developers/GitPython/issues/687
-  - name: Update pythongit library to version 2.1.13
-    pip:
-      virtualenv: "{{ devstack_dir.zuul }}"
-      name: "GitPython==2.1.13"
-      virtualenv_python: python2.7
-    become: True
-    tags: install-zuul
-
-  # Downgrade ecds library to last working version
-  - name: Downgrade ecdsa library to version 0.13.3
-    pip:
-      virtualenv: "{{ devstack_dir.zuul }}"
-      name: "ecdsa==0.13.3"
-      virtualenv_python: python2.7
-    become: True
-    tags: install-zuul
+- name: Install zuul venv package
+  unarchive:
+    src: "{{ zuul_venv_pkg }}"
+    dest: /opt/stack
+    remote_src: yes
+  become: True
+  tags: install-zuul

--- a/tasks/devstack/install-zuul.yaml
+++ b/tasks/devstack/install-zuul.yaml
@@ -1,12 +1,13 @@
-  - name: Make sure ubuntu user has access to /opt/stack
-    file:
-      path: /opt/stack
-      state: directory
-      recurse: yes
-      owner: ubuntu
-      group: ubuntu
-      mode: '0755'
-    become: True
+- name: Make sure ubuntu user has access to /opt/stack
+  file:
+    path: /opt/stack
+    state: directory
+    recurse: yes
+    owner: ubuntu
+    group: ubuntu
+    mode: '0755'
+  become: True
+  tags: install-zuul
 
 - name: Install zuul venv package
   unarchive:

--- a/tasks/devstack/install-zuul.yaml
+++ b/tasks/devstack/install-zuul.yaml
@@ -1,3 +1,13 @@
+  - name: Make sure ubuntu user has access to /opt/stack
+    file:
+      path: /opt/stack
+      state: directory
+      recurse: yes
+      owner: ubuntu
+      group: ubuntu
+      mode: '0755'
+    become: True
+
 - name: Install zuul venv package
   unarchive:
     src: "{{ zuul_venv_pkg }}"


### PR DESCRIPTION
We only use zuul 2.5.2 for the zuul-cloner utility. It requires older libraries and python2.7 and new versions of libraries/setuptools/pip keep breaking it.