### PR TITLE
Cherry pick neutron patch, adds missing process_name arg on Windows

### DIFF
--- a/job_vars/cinder-iscsi.yaml
+++ b/job_vars/cinder-iscsi.yaml
@@ -296,11 +296,11 @@ win_cherry_picks:
   - project: openstack/neutron
     path: "{{ win_dir.build }}\\neutron"
     patches:
-      - refs/changes/21/567621/13
-  - project: openstack/compute-hyperv
-    path: "{{ win_dir.build }}\\compute-hyperv"
-    patches:
-      - refs/changes/60/702660/2
+      - refs/changes/59/763159/1
+  # - project: openstack/compute-hyperv
+    # path: "{{ win_dir.build }}\\compute-hyperv"
+    # patches:
+      # - refs/changes/60/702660/2
 
 win_python_packages:
   - pywin32

--- a/job_vars/cinder-smb.yaml
+++ b/job_vars/cinder-smb.yaml
@@ -300,15 +300,15 @@ win_cherry_picks:
   - project: openstack/neutron
     path: "{{ win_dir.build }}\\neutron"
     patches:
-      - refs/changes/21/567621/13
-  - project: openstack/cinder
-    path: "{{ win_dir.build }}\\cinder"
-    patches:
-      - refs/changes/68/630168/1
-  - project: openstack/compute-hyperv
-    path: "{{ win_dir.build }}\\compute-hyperv"
-    patches:
-      - refs/changes/60/702660/2
+      - refs/changes/59/763159/1
+  # - project: openstack/cinder
+    # path: "{{ win_dir.build }}\\cinder"
+    # patches:
+      # - refs/changes/68/630168/1
+  # - project: openstack/compute-hyperv
+    # path: "{{ win_dir.build }}\\compute-hyperv"
+    # patches:
+      # - refs/changes/60/702660/2
 
 compute_driver: compute_hyperv.driver.HyperVDriver
 data_bridge_ovs: br-ethernet

--- a/job_vars/neutron.yaml
+++ b/job_vars/neutron.yaml
@@ -312,11 +312,11 @@ win_cherry_picks:
   - project: openstack/neutron
     path: "{{ win_dir.build }}\\neutron"
     patches:
-      - refs/changes/21/567621/13
-  - project: openstack/compute-hyperv
-    path: "{{ win_dir.build }}\\compute-hyperv"
-    patches:
-      - refs/changes/60/702660/2
+      - refs/changes/59/763159/1
+  # - project: openstack/compute-hyperv
+    # path: "{{ win_dir.build }}\\compute-hyperv"
+    # patches:
+      # - refs/changes/60/702660/2
 
 compute_driver: compute_hyperv.driver.HyperVDriver
 

--- a/job_vars/nova.yaml
+++ b/job_vars/nova.yaml
@@ -331,7 +331,7 @@ win_cherry_picks:
   - project: openstack/neutron
     path: "{{ win_dir.build }}\\neutron"
     patches:
-      - refs/changes/21/567621/13
+      - refs/changes/59/763159/1
 
 compute_driver: hyperv.driver.HyperVDriver
 

--- a/job_vars/os-brick-fc.yaml
+++ b/job_vars/os-brick-fc.yaml
@@ -250,7 +250,7 @@ win_cherry_picks:
   - project: openstack/neutron
     path: "{{ win_dir.build }}\\neutron"
     patches:
-      - refs/changes/21/567621/13
+      - refs/changes/59/763159/1
 #  - project: openstack/cinder
 #    path: "{{ win_dir.build }}\\cinder"
 #    patches:

--- a/job_vars/os-brick-iscsi.yaml
+++ b/job_vars/os-brick-iscsi.yaml
@@ -240,7 +240,7 @@ win_cherry_picks:
   - project: openstack/neutron
     path: "{{ win_dir.build }}\\neutron"
     patches:
-      - refs/changes/21/567621/13
+      - refs/changes/59/763159/1
 
 compute_driver: compute_hyperv.driver.HyperVDriver
 data_bridge_ovs: br-ethernet

--- a/job_vars/os-brick-smb.yaml
+++ b/job_vars/os-brick-smb.yaml
@@ -239,7 +239,7 @@ win_cherry_picks:
   - project: openstack/neutron
     path: "{{ win_dir.build }}\\neutron"
     patches:
-      - refs/changes/21/567621/13
+      - refs/changes/59/763159/1
 
 compute_driver: compute_hyperv.driver.HyperVDriver
 data_bridge_ovs: br-ethernet


### PR DESCRIPTION
add cherry-picks
* https://review.opendev.org/#/c/763159/ neutron - Add missing "process_name" argument on Windows

remove cherry-picks
* https://review.opendev.org/#/c/567621/ neutron - merged
* https://review.opendev.org/#/c/630168/ cinder - merged
* https://review.opendev.org/#/c/702660/ compute-hyperv - abandoned