### PR TITLE
Retry zuul cloner for failed git fetch/checkouts

### DIFF
--- a/tasks/devstack/prepare-git-repos.yaml
+++ b/tasks/devstack/prepare-git-repos.yaml
@@ -44,4 +44,7 @@
     shell: "{{ zuul_cloner_command }}"
     register: zuul_cloner_out
     become: True
+    until: zuul_cloner_out.rc == 0
+    retries: 5
+    delay: 10
     tags: prepare-git-repos

--- a/tasks/windows/prepare-git-repos.yaml
+++ b/tasks/windows/prepare-git-repos.yaml
@@ -28,6 +28,9 @@
     win_shell: "{{ zuul_cloner_command }}"
     register: zuul_cloner_out
     failed_when: False
+    until: zuul_cloner_out.rc == 0
+    retries: 5
+    delay: 10
     tags: prepare-git-repos
 
   - name: Write zuul-cloner log file


### PR DESCRIPTION
Retry zuul cloner in case the underlying git fetch/checkout commands that zuul runs fail.