### PR TITLE
Focal image devstack for victoria and up

### DIFF
--- a/build-devstack.yaml
+++ b/build-devstack.yaml
@@ -51,7 +51,7 @@
 
     - name: Applying cherry-picks
       cb_cherry_pick_devstack:
-        url: "{{ git_server }}/{{ item.project }}"
+        url: "{{ git_server + '/' + item.project if ( item.url | default('') | length == 0 ) else item.url }}"
         ref: "{{ item.patches }}"
         path: "{{ item.path }}"
       with_items: "{{ cherry_picks }}"

--- a/group_vars/devstack
+++ b/group_vars/devstack
@@ -43,7 +43,9 @@ apt_packages:
 apt_packages_remove:
   - python3-httplib2
   - python3-yaml
+  - python3-pyasn1
   - python3-pyasn1-modules
+  - python3-simplejson
 
 python_packages:
   - virtualenv

--- a/job_vars/cinder-iscsi.yaml
+++ b/job_vars/cinder-iscsi.yaml
@@ -22,6 +22,13 @@ log_key: /home/jenkins-slave/.ssh/id_rsa_log.pem
 log_path: /tmp/build_logs/{{ zuul_change }}-{{ zuul_patchset }}/{{ job_type }}
 
 ## devstack
+cherry_picks:
+  - project: openstack/devstack
+    path: "{{ devstack_dir.devstack }}"
+    url: "https://github.com/cloudbase/devstack"
+    patches:
+      - refs/heads/neutron-ovs-bridge-arping
+
 git_prep_projects:
   - openstack/keystone
   - openstack/glance

--- a/job_vars/cinder-iscsi.yaml
+++ b/job_vars/cinder-iscsi.yaml
@@ -1,7 +1,7 @@
 vms:
   - devstack: 
     name: "dv-cinder-{{ zuul_change }}-{{ zuul_patchset }}-{{ job_type }}"
-    image: bionic-09.08.2019
+    image: focal-15.04.2021
     flavor: devstack
     inventory_group: devstack
     additional_params: 'ansible_ssh_private_key_file=/home/jenkins-slave/.ssh/id_rsa.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'

--- a/job_vars/cinder-smb.yaml
+++ b/job_vars/cinder-smb.yaml
@@ -22,6 +22,13 @@ log_key: /home/jenkins-slave/.ssh/id_rsa_log.pem
 log_path: /tmp/build_logs/{{ zuul_change }}-{{ zuul_patchset }}/{{ job_type }}
 
 ## devstack
+cherry_picks:
+  - project: openstack/devstack
+    path: "{{ devstack_dir.devstack }}"
+    url: "https://github.com/cloudbase/devstack"
+    patches:
+      - refs/heads/neutron-ovs-bridge-arping
+
 git_prep_projects:
   - openstack/keystone
   - openstack/glance

--- a/job_vars/cinder-smb.yaml
+++ b/job_vars/cinder-smb.yaml
@@ -1,7 +1,7 @@
 vms:
   - devstack: 
     name: "dv-cinder-{{ zuul_change }}-{{ zuul_patchset }}-{{ job_type }}"
-    image: bionic-09.08.2019
+    image: focal-15.04.2021
     flavor: devstack
     inventory_group: devstack
     additional_params: 'ansible_ssh_private_key_file=/home/jenkins-slave/.ssh/id_rsa.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'

--- a/job_vars/neutron.yaml
+++ b/job_vars/neutron.yaml
@@ -22,6 +22,13 @@ log_key: /home/jenkins-slave/.ssh/id_rsa_log.pem
 log_path: /tmp/build_logs/{{ zuul_change }}-{{ zuul_patchset }}/{{ network_type }}
 
 ## devstack
+cherry_picks:
+  - project: openstack/devstack
+    path: "{{ devstack_dir.devstack }}"
+    url: "https://github.com/cloudbase/devstack"
+    patches:
+      - refs/heads/neutron-ovs-bridge-arping
+
 tempest_tests:
   included-tests: |
       tempest.api.network

--- a/job_vars/neutron.yaml
+++ b/job_vars/neutron.yaml
@@ -1,7 +1,7 @@
 vms:
   - devstack: 
     name: "dv-neutron-{{ zuul_change }}-{{ zuul_patchset }}-{{ network_type }}"
-    image: bionic-09.08.2019
+    image: focal-15.04.2021
     flavor: devstack
     inventory_group: devstack
     additional_params: 'ansible_ssh_private_key_file=/home/jenkins-slave/.ssh/id_rsa.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'

--- a/job_vars/nova-ceph.yaml
+++ b/job_vars/nova-ceph.yaml
@@ -36,7 +36,7 @@ vms:
 upper_constraints_pinning:
   - simplejson:
     project: 'simplejson'
-    value: 'simplejson===3.13.2'
+    value: 'simplejson===3.16.0'
 
 local_conf:
   enable_services:

--- a/job_vars/nova-ceph.yaml
+++ b/job_vars/nova-ceph.yaml
@@ -37,6 +37,12 @@ upper_constraints_pinning:
   - simplejson:
     project: 'simplejson'
     value: 'simplejson===3.16.0'
+  - pyasn1:
+    project: 'pyasn1'
+    value: 'pyasn1===0.4.8'
+  - pyasn1-modules:
+    project: 'pyasn1-modules'
+    value: 'pyasn1-modules===0.2.8'
 
 local_conf:
   enable_services:

--- a/job_vars/nova-ceph.yaml
+++ b/job_vars/nova-ceph.yaml
@@ -1,7 +1,7 @@
 vms:
   - devstack:
     name: "ncdv-{{ zuul_change }}-{{ zuul_patchset }}"
-    image: bionic-09.08.2019
+    image: focal-15.04.2021
     flavor: devstack
     inventory_group: devstack
     additional_params: 'ansible_ssh_private_key_file=/home/jenkins-slave/.ssh/id_rsa.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'

--- a/job_vars/nova.yaml
+++ b/job_vars/nova.yaml
@@ -1,7 +1,7 @@
 vms:
   - devstack: 
     name: "n-d-{{ zuul_change }}-{{ zuul_patchset }}"
-    image: bionic-09.08.2019
+    image: focal-15.04.2021
     flavor: devstack
     inventory_group: devstack
     additional_params: 'ansible_ssh_private_key_file=/home/jenkins-slave/.ssh/id_rsa.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'

--- a/job_vars/nova.yaml
+++ b/job_vars/nova.yaml
@@ -39,6 +39,11 @@ log_path: /tmp/build_logs/{{ zuul_change }}-{{ zuul_patchset }}/{{ job_type }}
 
 ## devstack
 cherry_picks:
+  - project: openstack/devstack
+    path: "{{ devstack_dir.devstack }}"
+    url: "https://github.com/cloudbase/devstack"
+    patches:
+      - refs/heads/neutron-ovs-bridge-arping
   - project: openstack/tempest
     path: "{{ devstack_dir.stack }}/tempest"
     patches:

--- a/job_vars/os-brick-ceph.yaml
+++ b/job_vars/os-brick-ceph.yaml
@@ -26,7 +26,7 @@ log_path: /tmp/build_logs/{{ zuul_change }}-{{ zuul_patchset }}/{{ job_type }}
 upper_constraints_pinning:
   - simplejson:
     project: 'simplejson'
-    value: 'simplejson===3.13.2'
+    value: 'simplejson===3.16.0'
 
 local_conf:
   enable_services:

--- a/job_vars/os-brick-ceph.yaml
+++ b/job_vars/os-brick-ceph.yaml
@@ -34,6 +34,12 @@ upper_constraints_pinning:
   - simplejson:
     project: 'simplejson'
     value: 'simplejson===3.16.0'
+  - pyasn1:
+    project: 'pyasn1'
+    value: 'pyasn1===0.4.8'
+  - pyasn1-modules:
+    project: 'pyasn1-modules'
+    value: 'pyasn1-modules===0.2.8'
 
 local_conf:
   enable_services:

--- a/job_vars/os-brick-ceph.yaml
+++ b/job_vars/os-brick-ceph.yaml
@@ -1,7 +1,7 @@
 vms:
   - devstack:
     name: "dv-osbrick-{{ zuul_change }}-{{ zuul_patchset }}-{{ job_type }}"
-    image: bionic-09.08.2019
+    image: focal-15.04.2021
     flavor: devstack
     inventory_group: devstack
     additional_params: 'ansible_ssh_private_key_file=/home/jenkins-slave/.ssh/id_rsa.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'

--- a/job_vars/os-brick-ceph.yaml
+++ b/job_vars/os-brick-ceph.yaml
@@ -22,6 +22,13 @@ log_key: /home/jenkins-slave/.ssh/id_rsa_log.pem
 log_path: /tmp/build_logs/{{ zuul_change }}-{{ zuul_patchset }}/{{ job_type }}
 
 ## devstack
+cherry_picks:
+  - project: openstack/devstack
+    path: "{{ devstack_dir.devstack }}"
+    url: "https://github.com/cloudbase/devstack"
+    patches:
+      - refs/heads/neutron-ovs-bridge-arping
+
 # ceph plugin installs simplejson as apt package and will conflict with other devstack automation
 upper_constraints_pinning:
   - simplejson:

--- a/job_vars/os-brick-iscsi.yaml
+++ b/job_vars/os-brick-iscsi.yaml
@@ -22,6 +22,13 @@ log_key: /home/jenkins-slave/.ssh/id_rsa_log.pem
 log_path: /tmp/build_logs/{{ zuul_change }}-{{ zuul_patchset }}/{{ job_type }}
 
 ## devstack
+cherry_picks:
+  - project: openstack/devstack
+    path: "{{ devstack_dir.devstack }}"
+    url: "https://github.com/cloudbase/devstack"
+    patches:
+      - refs/heads/neutron-ovs-bridge-arping
+
 local_conf:
   enable_services:
     - rabbit

--- a/job_vars/os-brick-iscsi.yaml
+++ b/job_vars/os-brick-iscsi.yaml
@@ -1,7 +1,7 @@
 vms:
   - devstack: 
     name: "dv-osbrick-{{ zuul_change }}-{{ zuul_patchset }}-{{ job_type }}"
-    image: bionic-09.08.2019
+    image: focal-15.04.2021
     flavor: devstack
     inventory_group: devstack
     additional_params: 'ansible_ssh_private_key_file=/home/jenkins-slave/.ssh/id_rsa.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'

--- a/job_vars/os-brick-smb.yaml
+++ b/job_vars/os-brick-smb.yaml
@@ -22,6 +22,13 @@ log_key: /home/jenkins-slave/.ssh/id_rsa_log.pem
 log_path: /tmp/build_logs/{{ zuul_change }}-{{ zuul_patchset }}/{{ job_type }}
 
 ## devstack
+cherry_picks:
+  - project: openstack/devstack
+    path: "{{ devstack_dir.devstack }}"
+    url: "https://github.com/cloudbase/devstack"
+    patches:
+      - refs/heads/neutron-ovs-bridge-arping
+
 local_conf:
   enable_services:
     - rabbit

--- a/job_vars/os-brick-smb.yaml
+++ b/job_vars/os-brick-smb.yaml
@@ -1,7 +1,7 @@
 vms:
   - devstack: 
     name: "dv-osbrick-{{ zuul_change }}-{{ zuul_patchset }}-{{ job_type }}"
-    image: bionic-09.08.2019
+    image: focal-15.04.2021
     flavor: devstack
     inventory_group: devstack
     additional_params: 'ansible_ssh_private_key_file=/home/jenkins-slave/.ssh/id_rsa.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'


### PR DESCRIPTION
* Update devstack VM image to Ubuntu Focal 
* Allow external repo cherry-pick to bypass arping failure when configuring 
  Neutron on Focal during stack
* Remove python3 apt packages: pyasn1-modules and simplejson 
  to avoid conflict with pip during stack
* pinning for packages installed by devstack ceph plugin for the ceph jobs
  to the versions installed by apt as pip will not be able to remove them