### PR TITLE
Disable glance quotas in devstack

### DIFF
--- a/templates/devstack/local.conf
+++ b/templates/devstack/local.conf
@@ -71,6 +71,7 @@ LOGFILE=$DEST/logs/stack.sh.log
 VERBOSE=True
 LOG_COLOR=False
 
+GLANCE_ENABLE_QUOTAS=False
 DOWNLOAD_DEFAULT_IMAGES=False
 IMAGE_URLS={{ local_conf.image_urls }}
 


### PR DESCRIPTION
tempest.api.compute.images.test_list_image_filters.ListImageFiltersTestJSON setUpClass creates 6 images and errors on the last one which is a snapshot in nova.