### PR TITLE
Ignore git SSL temp fix opendev cert errors with zuul-cloner ussuri

### DIFF
--- a/tasks/devstack/prepare-git-repos.yaml
+++ b/tasks/devstack/prepare-git-repos.yaml
@@ -40,6 +40,13 @@
     when: not zuul_head_only or zuul_head_only is not defined
     tags: prepare-git-repos
 
+  - name: "Set ssl backend for git to schannel for opendev repos certs"
+    shell: "git config --global http.sslverify false"
+
+  - name: "Set ssl backend for git to schannel for opendev repos certs"
+    shell: "git config --global http.sslverify false"
+    become: true
+
   - name: Run zuul-cloner
     shell: "{{ zuul_cloner_command }}"
     register: zuul_cloner_out

--- a/tasks/windows/prepare-git-repos.yaml
+++ b/tasks/windows/prepare-git-repos.yaml
@@ -22,6 +22,12 @@
     when: not zuul_head_only or zuul_head_only is not defined
     tags: prepare-git-repos
 
+  - name: "Set ssl backend for git to schannel for opendev repos certs"
+    win_shell: "git config --global http.sslbackend schannel"
+
+  - name: "Workaround for old python version of zuul-cloner, disable git ssl"
+    win_shell: "git config --global http.sslverify false"
+
   # zuul-cloner outputs on stderr, if we redirect 2>&1 the command always fails
   # we disable failure here to be able to write the log file in the next task and fail there if necessary
   - name: Run zuul-cloner


### PR DESCRIPTION
Workaround for zuul-cloner which runs in python 2.7 venv that can't recognize opendev repo certsWorkaround for zuul-cloner which runs in python 2.7 venv that can't recognize opendev repo certs