### PR TITLE
Retry apt operations and cache updates

### DIFF
--- a/tasks/devstack/install-apt-latest-packages.yaml
+++ b/tasks/devstack/install-apt-latest-packages.yaml
@@ -3,4 +3,6 @@
       name: "{{ apt_latest_packages }}"
       update_cache: yes
       state: latest
+    retries: 3
+    delay: 5
     become: True

--- a/tasks/devstack/install-apt-packages.yaml
+++ b/tasks/devstack/install-apt-packages.yaml
@@ -7,4 +7,6 @@
     apt:
       name: "{{ apt_packages }}"
       update_cache: yes
+    retries: 3
+    delay: 5
     become: True

--- a/tasks/devstack/remove-apt-packages.yaml
+++ b/tasks/devstack/remove-apt-packages.yaml
@@ -3,4 +3,6 @@
       name: "{{ apt_packages_remove }}"
       update_cache: yes
       state: absent
+    retries: 3
+    delay: 5
     become: True


### PR DESCRIPTION
 * Transient failures to fetch packages or update cache
   can occur due to failure in name resolution