### PR TITLE
Source keystone faster during local.sh

### DIFF
--- a/templates/devstack/local.sh
+++ b/templates/devstack/local.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source /home/ubuntu/keystonerc
+
 echo "Before updating nova flavors:"
 openstack flavor list
 


### PR DESCRIPTION
Devstack doesn't provide the env vars during stack.sh
anymore as it explicitly sets them for calls to openstack cli

Ref: https://review.opendev.org/c/openstack/devstack/+/780417