### PR TITLE
Add lock path in Openstack dirs and nova.conf

### DIFF
--- a/group_vars/windows
+++ b/group_vars/windows
@@ -15,6 +15,7 @@ win_dir:
   etc: 'c:\openstack\etc'
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
+  lock: 'c:\openstack\lock'
   python: 'c:\python27'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'

--- a/job_vars/cinder-iscsi.yaml
+++ b/job_vars/cinder-iscsi.yaml
@@ -239,6 +239,7 @@ win_dir:
   etc: 'c:\openstack\etc'
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
+  lock: 'c:\openstack\lock'
   python: 'c:\python37'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'

--- a/job_vars/cinder-smb.yaml
+++ b/job_vars/cinder-smb.yaml
@@ -239,6 +239,7 @@ win_dir:
   etc: 'c:\openstack\etc'
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
+  lock: 'c:\openstack\lock'
   python: 'c:\python37'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'

--- a/job_vars/compute-hyperv.yaml
+++ b/job_vars/compute-hyperv.yaml
@@ -342,6 +342,7 @@ win_dir:
   etc: 'c:\openstack\etc'
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
+  lock: 'c:\openstack\lock'
   python: 'c:\python37'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'

--- a/job_vars/neutron.yaml
+++ b/job_vars/neutron.yaml
@@ -303,6 +303,7 @@ win_dir:
   etc: 'c:\openstack\etc'
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
+  lock: 'c:\openstack\lock'
   python: 'c:\python37'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'

--- a/job_vars/nova.yaml
+++ b/job_vars/nova.yaml
@@ -341,6 +341,7 @@ win_dir:
   etc: 'c:\openstack\etc'
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
+  lock: 'c:\openstack\lock'
   python: 'c:\python37'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'

--- a/job_vars/os-brick-ceph.yaml
+++ b/job_vars/os-brick-ceph.yaml
@@ -268,6 +268,7 @@ win_dir:
   etc: 'c:\openstack\etc'
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
+  lock: 'c:\openstack\lock'
   python: 'c:\python37'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'

--- a/job_vars/os-brick-iscsi.yaml
+++ b/job_vars/os-brick-iscsi.yaml
@@ -235,6 +235,7 @@ win_dir:
   etc: 'c:\openstack\etc'
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
+  lock: 'c:\openstack\lock'
   python: 'c:\python37'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'

--- a/job_vars/os-brick-smb.yaml
+++ b/job_vars/os-brick-smb.yaml
@@ -234,6 +234,7 @@ win_dir:
   etc: 'c:\openstack\etc'
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
+  lock: 'c:\openstack\lock'
   python: 'c:\python37'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'

--- a/templates/windows/nova.conf
+++ b/templates/windows/nova.conf
@@ -24,6 +24,7 @@ transport_url = rabbit://stackrabbit:Passw0rd@{{ devstack_ip }}:5672/nova_cell1
 rpc_response_timeout = 600
 log_dir={{ win_dir.log }}
 log_file = nova-compute.log
+lock_path={{ win_dir.lock }}
 instance_usage_audit = True
 instance_usage_audit_period = hour
 notify_on_state_change = vm_and_task_state


### PR DESCRIPTION
Cinder iscsi, os-brick iscsi failing because lock_path, used by 
oslo concurency lockutils, is not defined in group [DEFAULT] in nova.conf