### PR TITLE
pin mportlib-metadata version to 4.8.2 for python3.6

### DIFF
--- a/group_vars/devstack
+++ b/group_vars/devstack
@@ -54,6 +54,7 @@ python_packages:
   - virtualenv
   - netaddr
   - netifaces
+  - importlib-metadata===4.8.2
 
 ## commented upper_constraints_pinning for there is no use of it right now
 ##upper_constraints_pinning:


### PR DESCRIPTION
importlib-metadata is a dependency for virtualenv and later versions require python 3.6.9 instead of >=3.7