### PR TITLE
Update win python to 3.8

### DIFF
--- a/group_vars/windows
+++ b/group_vars/windows
@@ -44,7 +44,7 @@ neutron_hyperv_agent:
 win_upper_constraints_pinning:
   - yappi:
     project: 'yappi'
-    value: 'yappi===1.0'
+    value: 'yappi===1.3.3'
 
 win_utils_bin_archive_url: http://10.100.0.9/ci/utils_bin.zip
 win_python_archive_url: http://10.100.0.9/ci/python.zip

--- a/job_vars/cinder-iscsi.yaml
+++ b/job_vars/cinder-iscsi.yaml
@@ -240,13 +240,13 @@ win_dir:
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
   lock: 'c:\openstack\lock'
-  python: 'c:\python37'
+  python: 'c:\python38'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'
   instances: 'C:\openstack\instances'
   event_log: 'c:\openstack\log\event-log'
 
-win_python_archive_url: http://10.100.0.9/ci/python37.zip
+win_python_archive_url: http://10.100.0.9/ci/python38.zip
 
 win_git_prep_projects:
   - openstack/requirements

--- a/job_vars/cinder-smb.yaml
+++ b/job_vars/cinder-smb.yaml
@@ -240,13 +240,13 @@ win_dir:
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
   lock: 'c:\openstack\lock'
-  python: 'c:\python37'
+  python: 'c:\python38'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'
   instances: 'C:\openstack\instances'
   event_log: 'c:\openstack\log\event-log'
 
-win_python_archive_url: http://10.100.0.9/ci/python37.zip
+win_python_archive_url: http://10.100.0.9/ci/python38.zip
 
 win_git_prep_projects:
   - openstack/requirements

--- a/job_vars/compute-hyperv.yaml
+++ b/job_vars/compute-hyperv.yaml
@@ -343,13 +343,13 @@ win_dir:
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
   lock: 'c:\openstack\lock'
-  python: 'c:\python37'
+  python: 'c:\python38'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'
   instances: 'C:\openstack\instances'
   event_log: 'c:\openstack\log\event-log'
 
-win_python_archive_url: http://10.100.0.9/ci/python37.zip
+win_python_archive_url: http://10.100.0.9/ci/python38.zip
 
 data_bridge_ovs: br-ethernet
 ovs_msi_url: http://10.100.0.9/ci/openvswitch-hyperv-installer-beta-2.12.msi

--- a/job_vars/neutron.yaml
+++ b/job_vars/neutron.yaml
@@ -304,13 +304,13 @@ win_dir:
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
   lock: 'c:\openstack\lock'
-  python: 'c:\python37'
+  python: 'c:\python38'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'
   instances: 'C:\openstack\instances'
   event_log: 'c:\openstack\log\event-log'
 
-win_python_archive_url: http://10.100.0.9/ci/python37.zip
+win_python_archive_url: http://10.100.0.9/ci/python38.zip
 
 
 data_bridge_ovs: br-ethernet

--- a/job_vars/nova.yaml
+++ b/job_vars/nova.yaml
@@ -342,13 +342,13 @@ win_dir:
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
   lock: 'c:\openstack\lock'
-  python: 'c:\python37'
+  python: 'c:\python38'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'
   instances: 'C:\openstack\instances'
   event_log: 'c:\openstack\log\event-log'
 
-win_python_archive_url: http://10.100.0.9/ci/python37.zip
+win_python_archive_url: http://10.100.0.9/ci/python38.zip
 
 data_bridge_ovs: br-ethernet
 ovs_msi_url: http://10.100.0.9/ci/openvswitch-hyperv-installer-beta-2.12.msi

--- a/job_vars/os-brick-ceph.yaml
+++ b/job_vars/os-brick-ceph.yaml
@@ -269,13 +269,13 @@ win_dir:
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
   lock: 'c:\openstack\lock'
-  python: 'c:\python37'
+  python: 'c:\python38'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'
   instances: 'C:\openstack\instances'
   event_log: 'c:\openstack\log\event-log'
 
-win_python_archive_url: http://10.100.0.9/ci/python37.zip
+win_python_archive_url: http://10.100.0.9/ci/python38.zip
 
 vmswitches:
   - name: "{{ data_bridge }}"

--- a/job_vars/os-brick-iscsi.yaml
+++ b/job_vars/os-brick-iscsi.yaml
@@ -236,13 +236,13 @@ win_dir:
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
   lock: 'c:\openstack\lock'
-  python: 'c:\python37'
+  python: 'c:\python38'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'
   instances: 'C:\openstack\instances'
   event_log: 'c:\openstack\log\event-log'
 
-win_python_archive_url: http://10.100.0.9/ci/python37.zip
+win_python_archive_url: http://10.100.0.9/ci/python38.zip
 
 vmswitches:
   - name: "{{ data_bridge }}"

--- a/job_vars/os-brick-smb.yaml
+++ b/job_vars/os-brick-smb.yaml
@@ -235,13 +235,13 @@ win_dir:
   build: 'c:\openstack\build'
   tmp: 'c:\openstack\tmp'
   lock: 'c:\openstack\lock'
-  python: 'c:\python37'
+  python: 'c:\python38'
   python_zuul: 'c:\python27'
   pip: 'C:\ProgramData\pip'
   instances: 'C:\openstack\instances'
   event_log: 'c:\openstack\log\event-log'
 
-win_python_archive_url: http://10.100.0.9/ci/python37.zip
+win_python_archive_url: http://10.100.0.9/ci/python38.zip
 
 vmswitches:
   - name: "{{ data_bridge }}"


### PR DESCRIPTION
Openstack Xena has changed the python version requirement to >=python3.8, update the python archive for windows as 
the devstack focal machine already has python3.8.