### PR TITLE
Fix get pip behavior if setuptools is already present

### DIFF
--- a/tasks/devstack/install-pip.yaml
+++ b/tasks/devstack/install-pip.yaml
@@ -1,3 +1,10 @@
+  # Workaroound for https://github.com/pypa/pip/issues/10742
+  # to make get-pip idempotent
+  - name: Uninstall setuptools
+    shell: pip uninstall setuptools -y
+    become: True
+    ignore_errors: yes
+
   - name: Download get-pip.py from {{ get_pip_url }}
     get_url:
       url: "{{ get_pip_url }}"

--- a/tasks/devstack/run-stack.yaml
+++ b/tasks/devstack/run-stack.yaml
@@ -18,6 +18,9 @@
       
   - name: Run stack
     shell: |
+      # workaround get-pip breaking when setuptools installed
+      # ref: https://github.com/pypa/pip/issues/10742
+      sudo -H -E pip3 uninstall setuptools -y || true
       ./unstack.sh > /dev/null 2>&1
       ./stack.sh > /dev/null 2>&1
     args:

--- a/tasks/windows/install-pip.yaml
+++ b/tasks/windows/install-pip.yaml
@@ -13,5 +13,5 @@
         {{ pip_version }}
 
   - name: Install pip version "{{ pip_version }}"
-    win_shell: python "{{ win_dir.tmp }}\\get-pip.py" -c "{{ win_dir.tmp }}\\constraints.txt" pip
+    win_shell: python "{{ win_dir.tmp }}\\get-pip.py" -c "{{ win_dir.tmp }}\\constraints.txt" pip --no-setuptools
     tags: install-pip


### PR DESCRIPTION
Get pip currently holds a copy of pip 21.3.1 and implicitly installs setuptools, will error out if setuptools is present so multiple runs are not idempotent and stack.sh uses get-pip as well.
* uninstall setuptools in devstack machine before running get-pip and before running stack.sh
* skip setuptools explicitly on windows when using get-pip