### PR TITLE
Upgrade pip version

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -8,7 +8,7 @@ git_server: https://opendev.org
 
 get_pip_url: https://bootstrap.pypa.io/get-pip.py
   
-pip_version: pip==20.2.2
+pip_version: pip==21.3.1
 pip_ini_content: | 
   [global]
   index-url = http://10.100.0.9:8080/cloudbase/CI/+simple/

--- a/group_vars/devstack
+++ b/group_vars/devstack
@@ -5,7 +5,7 @@ ansible_ssh_user: ubuntu
 ansible_become_pass: "{{ ansible_ssh_pass }}"
 ansible_python_interpreter: /usr/bin/python3
 
-setuptools_version: setuptools<50.0.0
+setuptools_version: setuptools===60.2.0
 
 # used for checking if services are up (tasks/devstack/check-devstack-nova-services.yaml)
 service_check_retries: 12

--- a/job_vars/cinder-iscsi.yaml
+++ b/job_vars/cinder-iscsi.yaml
@@ -250,12 +250,13 @@ win_python_archive_url: http://10.100.0.9/ci/python37.zip
 
 win_git_prep_projects:
   - openstack/requirements
-  - openstack/nova
-  - openstack/neutron
-  - openstack/compute-hyperv
   - openstack/cinder
-  - openstack/os-win
+  - openstack/nova
+  - openstack/compute-hyperv
   - openstack/networking-hyperv
+  - openstack/neutron
+  - openstack/os-win
+
 
 services:
   - nova:

--- a/job_vars/cinder-smb.yaml
+++ b/job_vars/cinder-smb.yaml
@@ -252,10 +252,10 @@ win_git_prep_projects:
   - openstack/requirements
   - openstack/cinder
   - openstack/nova
-  - openstack/neutron
   - openstack/compute-hyperv
-  - openstack/os-win
   - openstack/networking-hyperv
+  - openstack/neutron
+  - openstack/os-win
 
 services:
   - nova:

--- a/job_vars/compute-hyperv.yaml
+++ b/job_vars/compute-hyperv.yaml
@@ -310,9 +310,9 @@ win_git_prep_projects:
   - openstack/requirements
   - openstack/nova
   - openstack/compute-hyperv
+  - openstack/networking-hyperv
   - openstack/neutron
   - openstack/os-win
-  - openstack/networking-hyperv
 
 services:
   - nova:

--- a/job_vars/neutron.yaml
+++ b/job_vars/neutron.yaml
@@ -270,10 +270,10 @@ join_ad: False
 win_git_prep_projects:
   - openstack/requirements
   - openstack/nova
-  - openstack/neutron
   - openstack/compute-hyperv
-  - openstack/os-win
   - openstack/networking-hyperv
+  - openstack/neutron
+  - openstack/os-win
   
 services:
   - nova:

--- a/job_vars/nova-ceph.yaml
+++ b/job_vars/nova-ceph.yaml
@@ -184,10 +184,10 @@ ad_domain: "nc-{{ zuul_change }}-{{ zuul_patchset }}.local"
 win_git_prep_projects:
   - openstack/requirements
   - openstack/nova
-  - openstack/neutron
-  - openstack/os-win
-  - openstack/os-brick
   - openstack/networking-hyperv
+  - openstack/neutron
+  - openstack/os-brick
+  - openstack/os-win
 
 win_cherry_picks:
   - project: openstack/os-brick

--- a/job_vars/nova.yaml
+++ b/job_vars/nova.yaml
@@ -309,9 +309,9 @@ join_ad: True
 win_git_prep_projects:
   - openstack/requirements
   - openstack/nova
+  - openstack/networking-hyperv
   - openstack/neutron
   - openstack/os-win
-  - openstack/networking-hyperv
   
 services:
   - nova:

--- a/job_vars/os-brick-ceph.yaml
+++ b/job_vars/os-brick-ceph.yaml
@@ -227,11 +227,11 @@ join_ad: False
 win_git_prep_projects:
   - openstack/requirements
   - openstack/nova
-  - openstack/neutron
   - openstack/compute-hyperv
-  - openstack/os-win
-  - openstack/os-brick
   - openstack/networking-hyperv
+  - openstack/neutron
+  - openstack/os-brick
+  - openstack/os-win
 
 services:
   - nova:

--- a/job_vars/os-brick-iscsi.yaml
+++ b/job_vars/os-brick-iscsi.yaml
@@ -197,11 +197,11 @@ win_git_prep_projects:
   - openstack/requirements
   - openstack/cinder
   - openstack/nova
-  - openstack/neutron
   - openstack/compute-hyperv
-  - openstack/os-win
-  - openstack/os-brick
   - openstack/networking-hyperv
+  - openstack/neutron
+  - openstack/os-brick
+  - openstack/os-win
 
 services:
   - nova:

--- a/job_vars/os-brick-smb.yaml
+++ b/job_vars/os-brick-smb.yaml
@@ -196,11 +196,11 @@ win_git_prep_projects:
   - openstack/requirements
   - openstack/cinder
   - openstack/nova
-  - openstack/neutron
   - openstack/compute-hyperv
-  - openstack/os-win
-  - openstack/os-brick
   - openstack/networking-hyperv
+  - openstack/neutron
+  - openstack/os-brick
+  - openstack/os-win
 
 services:
   - nova:

--- a/tasks/devstack/install-networking-hyperv.yaml
+++ b/tasks/devstack/install-networking-hyperv.yaml
@@ -1,8 +1,7 @@
   - name: Install networking-hyperv
-    pip:
-      #executable: pip2
-      name: /opt/stack/networking-hyperv
-      extra_args: -c /opt/stack/requirements/upper-constraints.txt
-      editable: yes
+    # Explicitly install with environment in shell to keep package editable
+    shell: pip3 install -e /opt/stack/networking-hyperv -c /opt/stack/requirements/upper-constraints.txt
+    environment:
+      SETUPTOOLS_USE_DISTUTILS: stdlib
     become: True
     tags: networking-hyperv

--- a/tasks/windows/install-project.yaml
+++ b/tasks/windows/install-project.yaml
@@ -23,8 +23,12 @@
       backslash: "\\"
     tags: install-project
 
-  - name: "Running edit-constraints for {{ project_name }} in {{ project_folder }}"
-    win_shell: 'edit-constraints {{ win_dir.build }}\\requirements\\upper-constraints.txt -- {{ project_name }} "-e file:///{{ repo_path }}/{{ project_name }}#egg={{ project_name }}"'
+  - name: "Ensure direct reference to {{ project_name }} in pip constraints"
+    win_lineinfile:
+      path: '{{ win_dir.build }}\\requirements\\upper-constraints.txt'
+      regexp: '^{{ project_name }}[^-] *.*(@|<|>|=).*'
+      line: '{{project_name }} @ file:///{{ repo_path }}/{{ project_name }}#egg={{ project_name }}'
+      newline: unix
     when: project_name != "openstack_requirements"
     tags: install-project
 


### PR DESCRIPTION
* Bump pip and setuptools versions.
* Pip would output installed successfully and exit without a return code but the project would not get installed at all, use stdlib value in environment when installing netorking-hyperv on devstack similar to how openstack/devstack installs projects in editable mode.
* Pip no longer supports editable constraints, use direct reference to projects in constraints file for windows. Drop edit-constraints as it does not support the new direct reference pip wants, use ansible win_lineinfile with regexp instead.
* Change project install order on windows to maintain all pip installs in editable mode