### PR TITLE
Mark cherry-pick repo dir as safe for git when user differs | wallaby

### DIFF
--- a/library/cb_cherry_pick_devstack.py
+++ b/library/cb_cherry_pick_devstack.py
@@ -24,6 +24,7 @@ def main():
     # make sure we have these set
     Popen("git config --global user.email cbci@cloudbasesolutions.com".split(), stdout=PIPE, stderr=PIPE).communicate()
     Popen("git config --global user.name CBCI".split(), stdout=PIPE, stderr=PIPE).communicate()
+    Popen(("git config --global --add safe.directory %s" % path).split(), stdout=PIPE, stderr=PIPE).communicate()
 
     for r in ref:
         result[r] = dict()


### PR DESCRIPTION
devstack repo is grabbed under ubuntu user and the Openstack repos under root with sudo by devstack,
cherry-pick on devstack would fail because of git reporting unsafe