### PR TITLE
Use distro pip and setuptools

### DIFF
--- a/build-devstack.yaml
+++ b/build-devstack.yaml
@@ -36,7 +36,7 @@
     - include: tasks/devstack/install-apt-packages.yaml
     - include: tasks/devstack/install-apt-latest-packages.yaml
     - include: tasks/devstack/remove-apt-packages.yaml
-    - include: tasks/devstack/install-pip.yaml
+    #- include: tasks/devstack/install-pip.yaml
     - include: tasks/devstack/configure-pip-index.yaml
     - include: tasks/devstack/install-python-packages.yaml
 

--- a/group_vars/devstack
+++ b/group_vars/devstack
@@ -39,6 +39,8 @@ apt_packages:
   - python2.7-dev
   - python3-dev
   - libpcre3-dev
+  - python3-pip
+  - python3-setuptools
 
 
 apt_latest_packages:


### PR DESCRIPTION
Devstack dropped installing setuptools for ubuntu and use distro pip, so just ensure that they are pre-installed